### PR TITLE
Show appropriate dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10545,6 +10545,11 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-router": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.2.tgz",
+      "integrity": "sha512-opKtsxjp9eOcFWdp6xLQPLmRGgfM932Tl56U9chYTnoWqKxQ8M20N7AkdEbM5beUh6wICoFGYugAX9vQjyJLFg=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "vue": "^2.5.21",
+    "vue-router": "^3.0.2",
     "vuex": "^3.1.0"
   },
   "devDependencies": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,17 +1,14 @@
 <template>
   <div id="app">
-    <img alt="Vue logo" src="./assets/logo.png">
-    <HelloWorld msg="Welcome to Your Vue.js App"/>
+    <router-view></router-view>
   </div>
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
 
 export default {
   name: 'app',
   components: {
-    HelloWorld
   }
 }
 </script>

--- a/frontend/src/Dashboard.vue
+++ b/frontend/src/Dashboard.vue
@@ -21,7 +21,7 @@ export default {
         ...mapState([
             'currentUser'
         ]),
-        getAccountType: function () {
+        getAccountType () {
             return this.currentUser.AccountType
         }
     }

--- a/frontend/src/Dashboard.vue
+++ b/frontend/src/Dashboard.vue
@@ -1,0 +1,30 @@
+<template>
+    <div>
+        <p>Current User's name: {{ currentUser.username }} | Account Type: {{ currentUser.AccountType }}</p>
+        <farm-dashboard v-if="getAccountType === 'farmer'"></farm-dashboard>
+        <user-dashboard v-else></user-dashboard>
+    </div>
+</template>
+
+<script>
+import UserDashboard from './UserDashboard.vue'
+import FarmDashboard from './FarmDashboard.vue'
+import { mapState } from 'vuex'
+
+export default {
+    components: {
+        'farm-dashboard': FarmDashboard,
+        'user-dashboard': UserDashboard,        
+    },
+
+    computed: {
+        ...mapState([
+            'currentUser'
+        ]),
+        getAccountType: function () {
+            return this.currentUser.AccountType
+        }
+    }
+}
+</script>
+

--- a/frontend/src/UserDashboard.vue
+++ b/frontend/src/UserDashboard.vue
@@ -1,0 +1,12 @@
+<template>
+    <div>
+      <h1>This will be the User Dashboard</h1>
+    </div>
+</template>
+
+<script>
+export default {
+    
+}
+</script>
+

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="hello">
-    <h1>{{ msg }}</h1>
+    <h1>This is the Home Page</h1>
     
   </div>
 </template>
@@ -8,9 +8,6 @@
 <script>
 export default {
   name: 'HelloWorld',
-  props: {
-    msg: String
-  }
 }
 </script>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,11 +1,20 @@
 import Vue from 'vue';
 import App from './App.vue';
+import VueRouter from 'vue-router'
+import Routes from './routes'
 
 import store from './store';
 
 Vue.config.productionTip = false
 
+Vue.use(VueRouter);
+
+const router = new VueRouter({
+  routes: Routes
+});
+
 new Vue({
   render: h => h(App),
   store,
+  router,
 }).$mount('#app');

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,0 +1,7 @@
+import HelloWorld from './components/HelloWorld.vue';
+import Dashboard from './Dashboard.vue';
+
+export default [
+    { path: '/', component: HelloWorld},
+    { path: '/dashboard', component: Dashboard},
+]

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,6 +4,9 @@ import vue from 'vue';
 vue.use(vuex);
 
 export default new vuex.Store({
-  
+    state: {
+        currentUser: {id:1, username: "John", AccountType: "farmer", isLoggedIn: true},
+        
+    }
 })
 


### PR DESCRIPTION
Made the following changes (all frontend stuff):

- Installed Vue Router, modified main.js file to use vue router

- Added routes.js file, created two routes, '/' for home page, '/dashboard' to show either user dashboard or famer dashboard. At /dashboard, the new Dashboard.vue component decides which dashboard to show based on account type of the logged in user. 

- Added UserDashboard.vue to hold user dashboard component. Not fully built yet, currently just displays a message indicating that it is the user dashboard.

- Added temporary data to the vuex store. To test functionality, change the "AccountType" to either "farmer" or "user".
