### PR TITLE
added null check to appSettings.Secret in Startup

### DIFF
--- a/MooreMarket/Program.cs
+++ b/MooreMarket/Program.cs
@@ -39,6 +39,7 @@ namespace MooreMarket
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .CaptureStartupErrors(false);
     }
 }

--- a/MooreMarket/Startup.cs
+++ b/MooreMarket/Startup.cs
@@ -1,8 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using AutoMapper;
 using Microsoft.IdentityModel.Tokens;
@@ -18,9 +20,12 @@ namespace MooreMarket
 {
   public class Startup
     {
-        public Startup(IConfiguration configuration)
+        private readonly ILogger _logger;
+        
+        public Startup(IConfiguration configuration, ILogger<Startup> logger)
         {
             Configuration = configuration;
+            _logger = logger;
         }
 
         public IConfiguration Configuration { get; }
@@ -44,6 +49,10 @@ namespace MooreMarket
             services.Configure<AppSettings>(appSettingsSection);
 
             var appSettings = appSettingsSection.Get<AppSettings>();
+            if (appSettings == null || (String.IsNullOrEmpty(appSettings.Secret))) {
+              _logger.LogError("No secret key provided in appsettings");
+              throw new ArgumentNullException("appSettings.secret is null or empty");
+            }
             var key = Encoding.ASCII.GetBytes(appSettings.Secret);
             services.AddAuthentication(x =>
             {
@@ -76,7 +85,9 @@ namespace MooreMarket
                 ValidateAudience = false
               };
             });
-
+            
+            
+            
             services.AddScoped<IUserService, UserService>();
         }
 

--- a/MooreMarket/appsettings.Development.json
+++ b/MooreMarket/appsettings.Development.json
@@ -10,7 +10,7 @@
   "ConnectionStrings": {
     "Default": "server=localhost;port=8889;database=moore-market;user=moore-market;password=password"
   },
-  "AppSettings": {
+  "AppSettings" : {
     "Secret" : "THIS SHOULD BE GENERATED AND STORED SECURELY FOR PRODUCTION"
   }
 }


### PR DESCRIPTION
Nothing major going on here. Just does a null check on appSettings.Secret inside Startup which throws an exception that shuts down the app and logs a message to the console indicating the secret key is not provided. 